### PR TITLE
Add universal prefix removal (Issue #25)

### DIFF
--- a/cpp_to_rust/cpp_to_rust_generator/src/config.rs
+++ b/cpp_to_rust/cpp_to_rust_generator/src/config.rs
@@ -189,6 +189,8 @@ pub struct Config {
   cpp_data_filters: Vec<CppDataFilter>,
   cpp_filtered_namespaces: Vec<String>,
 
+  prefixes_to_remove: Vec<String>,
+  
   type_allocation_places: HashMap<String, CppTypeAllocationPlace>,
 }
 
@@ -209,6 +211,7 @@ impl Config {
       cpp_data_filters: Default::default(),
       cpp_filtered_namespaces: Default::default(),
       cpp_build_config: Default::default(),
+      prefixes_to_remove: Default::default(),
       type_allocation_places: Default::default(),
       cpp_lib_version: None,
     }
@@ -364,6 +367,20 @@ impl Config {
     }
   }
 
+  /// Adds a prefix to remove from C++ datatype and method names
+  pub fn add_prefix_to_remove<N: Into<String>>(&mut self, prefix: N) {
+    self.prefixes_to_remove.push(prefix.into());
+  }
+
+  /// Adds multiple prefixes to remove from C++ datatype and method names
+  pub fn add_prefixes_to_remove<Item, Iter>(&mut self, prefixes: Iter)
+    where Item: Into<String>,
+          Iter: IntoIterator<Item = Item>
+  {
+    for prefix in prefixes {
+      self.add_prefix_to_remove(prefix.into());
+    }
+  }
 
   /// Overrides automatic selection of type allocation place for `type_name` and uses `place`
   /// instead. See `CppTypeAllocationPlace` for more information.
@@ -476,6 +493,12 @@ impl Config {
   pub fn cpp_build_config(&self) -> &CppBuildConfig {
     &self.cpp_build_config
   }
+
+  /// Returns current `prefixes_to_remove` value
+  pub fn prefixes_to_remove(&self) -> &Vec<String> {
+    &self.prefixes_to_remove
+  }
+
   /// Returns values added by `Config::set_type_allocation_place`.
   /// Keys of the hash map are names of C++ types.
   pub fn type_allocation_places(&self) -> &HashMap<String, CppTypeAllocationPlace> {

--- a/cpp_to_rust/cpp_to_rust_generator/src/launcher.rs
+++ b/cpp_to_rust/cpp_to_rust_generator/src/launcher.rs
@@ -68,7 +68,6 @@ pub fn exec<T: Iterator<Item = Config>>(configs: T) -> Result<()> {
   let mut dependency_cache = HashMap::new();
   for config in configs {
 
-
     {
       let cpp_data = load_or_create_cpp_data(
         &config,
@@ -133,17 +132,17 @@ pub fn exec<T: Iterator<Item = Config>>(configs: T) -> Result<()> {
       };
       log::status("Preparing Rust functions");
       let rust_data = rust_generator::RustGeneratorInputData {
-        cpp_data: &cpp_data,
-        cpp_ffi_headers: cpp_ffi_headers,
-        dependency_types: dependencies
-          .iter()
-          .map(|dep| &dep.rust_export_info.rust_types as &[_])
-          .collect(),
-        crate_name: config.crate_properties().name().clone(),
-        // TODO: more universal prefix removal (#25)
-        remove_qt_prefix: remove_qt_prefix,
-        filtered_namespaces: config.cpp_filtered_namespaces().clone(),
-      }.run()
+          cpp_data: &cpp_data,
+          cpp_ffi_headers: cpp_ffi_headers,
+          dependency_types: dependencies
+            .iter()
+            .map(|dep| &dep.rust_export_info.rust_types as &[_])
+            .collect(),
+          crate_name: config.crate_properties().name().clone(),
+          prefixes_to_remove: config.prefixes_to_remove().clone(),
+          filtered_namespaces: config.cpp_filtered_namespaces().clone(),
+        }
+        .run()
         .chain_err(|| "Rust data generator failed")?;
       log::status(format!(
         "Generating Rust crate code ({})",


### PR DESCRIPTION
This PR adds universal removal to the API. A caller can specify which prefixes to remove in a similar matter to other Config members. Automatic detection is not yet implemented, but shouldn't be hard to add.

I tried to match the style and semantics of existing code. Hope this helps!