### PR TITLE
Update libraries to stable release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,10 @@
+[workspace]
+members = [
+    "cpp_to_rust/cpp_to_rust_build_tools",
+    "cpp_to_rust/cpp_to_rust_common",
+    "cpp_to_rust/cpp_to_rust_generator",
+    "cpp_to_rust/cpp_utils",
+    "qt_generator/qt_build_tools",
+    "qt_generator/qt_generator",
+    "qt_generator/qt_generator_common",
+]

--- a/cpp_to_rust/cpp_to_rust_build_tools/src/lib.rs
+++ b/cpp_to_rust/cpp_to_rust_build_tools/src/lib.rs
@@ -10,7 +10,7 @@
 
 
 pub extern crate cpp_to_rust_common as common;
-use common::errors::{fancy_unwrap, ChainErr, Result};
+use common::errors::{fancy_unwrap, ResultExt, Result};
 use common::cpp_build_config::{CppBuildConfig, CppBuildPaths, CppLibraryType};
 use common::BuildScriptData;
 use common::file_utils::{PathBufWithAdded, load_json, create_file, file_to_string, path_to_str};

--- a/cpp_to_rust/cpp_to_rust_common/Cargo.toml
+++ b/cpp_to_rust/cpp_to_rust_common/Cargo.toml
@@ -14,19 +14,16 @@ repository = "https://github.com/rust-qt/cpp_to_rust/tree/master/cpp_to_rust/cpp
 error-chain = "0.5" # error handling
 backtrace = "0.2.1" # error backtrace manipulation
 
-regex = "0.1"
+regex = "1.0"
 
-serde = "0.9"       # serialization
-serde_derive = "0.9"
-serde_json = "0.9"
-bincode = "0.7.0"
+serde = "1.0"       # serialization
+serde_derive = "1.0"
+serde_json = "1.0"
+bincode = "1.0"
 
 term-painter = "0.2.3"   # colored output
 
 num_cpus = "1.0.0"  # detect preferred task count
 
 toml = "0.2" # toml generation and parsing
-lazy_static = "0.2"
-
-[build-dependencies]
-serde_codegen = "0.9"
+lazy_static = "1.1"

--- a/cpp_to_rust/cpp_to_rust_common/Cargo.toml
+++ b/cpp_to_rust/cpp_to_rust_common/Cargo.toml
@@ -11,8 +11,8 @@ license = "MIT"
 repository = "https://github.com/rust-qt/cpp_to_rust/tree/master/cpp_to_rust/cpp_to_rust_common"
 
 [dependencies]
-error-chain = "0.5" # error handling
-backtrace = "0.2.1" # error backtrace manipulation
+error-chain = "0.11" # error handling
+backtrace = "0.3" # error backtrace manipulation
 
 regex = "1.0"
 

--- a/cpp_to_rust/cpp_to_rust_common/Cargo.toml
+++ b/cpp_to_rust/cpp_to_rust_common/Cargo.toml
@@ -25,5 +25,5 @@ term-painter = "0.2.3"   # colored output
 
 num_cpus = "1.0.0"  # detect preferred task count
 
-toml = "0.2" # toml generation and parsing
+toml = "0.4" # toml generation and parsing
 lazy_static = "1.1"

--- a/cpp_to_rust/cpp_to_rust_common/src/errors.rs
+++ b/cpp_to_rust/cpp_to_rust_common/src/errors.rs
@@ -7,19 +7,16 @@ use std;
 
 error_chain! {
   foreign_links {
-    std::io::Error, IO;
-    ::regex::Error, Regex;
+    IO(std::io::Error);
+    Regex(::regex::Error);
   }
 
   errors {
     Unexpected(msg: String) {
       display("{}", msg)
     }
-
   }
 }
-
-use backtrace::Symbol;
 
 impl Error {
   /// Returns true if this error was not deemed possible
@@ -99,17 +96,18 @@ pub fn unexpected<S: Into<String>>(text: S) -> ErrorKind {
   ErrorKind::Unexpected(text.into())
 }
 
-impl<T> ChainErr<T> for Option<T> {
-  fn chain_err<F, EK>(self, callback: F) -> Result<T>
-    where F: FnOnce() -> EK,
-          EK: Into<ErrorKind>
-  {
-    match self {
-      Some(x) => Ok(x),
-      None => Err(Error::from("None encountered")).chain_err(callback),
-    }
-  }
-}
+// impl<T> ChainedError for Option<T> {
+//   type ErrorKind = ErrorKind;
+//   fn chain_err<F, EK>(self, callback: F) -> Result<T>
+//     where F: FnOnce() -> EK,
+//           EK: Into<ErrorKind>
+//   {
+//     match self {
+//       Some(x) => Ok(x),
+//       None => Err(Error::from("None encountered")).chain_err(callback),
+//     }
+//   }
+// }
 
 /// Works like `unwrap()`, but in case of an error,
 /// outputs formatted stack trace and

--- a/cpp_to_rust/cpp_to_rust_common/src/file_utils.rs
+++ b/cpp_to_rust/cpp_to_rust_common/src/file_utils.rs
@@ -1,7 +1,7 @@
 //! Various utilities for working with files
 
 use log;
-use errors::{Result, ChainErr};
+use errors::{Result, ResultExt};
 
 use std::path::{Path, PathBuf};
 use std::fs;

--- a/cpp_to_rust/cpp_to_rust_common/src/file_utils.rs
+++ b/cpp_to_rust/cpp_to_rust_common/src/file_utils.rs
@@ -208,11 +208,9 @@ pub fn save_bincode<P: AsRef<Path>, T: ::serde::Serialize>(path: P, value: &T) -
 }
 
 /// Load data from a TOML file
-pub fn load_toml<P: AsRef<Path>>(path: P) -> Result<toml::Table> {
+pub fn load_toml<P: AsRef<Path>>(path: P) -> Result<toml::value::Table> {
   let data = file_to_string(path.as_ref())?;
-  let mut parser = toml::Parser::new(&data);
-  parser
-    .parse()
+  toml::from_str(&data)
     .chain_err(|| format!("failed to parse TOML file: {}", path.as_ref().display()))
 }
 

--- a/cpp_to_rust/cpp_to_rust_common/src/file_utils.rs
+++ b/cpp_to_rust/cpp_to_rust_common/src/file_utils.rs
@@ -178,7 +178,7 @@ impl FileWrapper {
 }
 
 /// Deserialize value from JSON file `path`.
-pub fn load_json<P: AsRef<Path>, T: ::serde::Deserialize>(path: P) -> Result<T> {
+pub fn load_json<P: AsRef<Path>, T: ::serde::de::DeserializeOwned>(path: P) -> Result<T> {
   let file = open_file(path.as_ref())?;
   ::serde_json::from_reader(file.into_file())
     .chain_err(|| format!("failed to parse file as JSON: {}", path.as_ref().display()))
@@ -194,16 +194,16 @@ pub fn save_json<P: AsRef<Path>, T: ::serde::Serialize>(path: P, value: &T) -> R
 }
 
 /// Deserialize value from binary file `path`.
-pub fn load_bincode<P: AsRef<Path>, T: ::serde::Deserialize>(path: P) -> Result<T> {
+pub fn load_bincode<P: AsRef<Path>, T: ::serde::de::DeserializeOwned>(path: P) -> Result<T> {
   let mut file = open_file(path.as_ref())?.into_file();
-  ::bincode::deserialize_from(&mut file, ::bincode::Infinite)
+  ::bincode::deserialize_from(&mut file)
     .chain_err(|| format!("load_bincode failed: {}", path.as_ref().display()))
 }
 
 /// Serialize `value` into binary file `path`.
 pub fn save_bincode<P: AsRef<Path>, T: ::serde::Serialize>(path: P, value: &T) -> Result<()> {
   let mut file = create_file(path.as_ref())?.into_file();
-  ::bincode::serialize_into(&mut file, value, ::bincode::Infinite)
+  ::bincode::serialize_into(&mut file, value)
     .chain_err(|| format!("save_bincode failed: {}", path.as_ref().display()))
 }
 

--- a/cpp_to_rust/cpp_to_rust_common/src/utils.rs
+++ b/cpp_to_rust/cpp_to_rust_common/src/utils.rs
@@ -1,6 +1,6 @@
 //! Various utilities.
 
-use errors::{Result, ChainErr};
+use errors::{Result, ResultExt};
 use log;
 
 use std;

--- a/cpp_to_rust/cpp_to_rust_generator/Cargo.toml
+++ b/cpp_to_rust/cpp_to_rust_generator/Cargo.toml
@@ -14,13 +14,13 @@ regex = "1.0"
 serde = "1.0"       # serialization
 serde_derive = "1.0"
 
-clang = "0.16"    # C++ parsing
+clang = "0.20"    # C++ parsing
 
 select = "0.4.2"    # html parsing
 
 tempdir = "0.3.5"   # temporary directory creation
 
-rustfmt = "0.6"     # Rust code formatting
+rustfmt = "0.10"     # Rust code formatting
 
 clippy = {version = "0.0", optional = true} # linter
 

--- a/cpp_to_rust/cpp_to_rust_generator/Cargo.toml
+++ b/cpp_to_rust/cpp_to_rust_generator/Cargo.toml
@@ -9,10 +9,10 @@ exclude = ["test_assets/**/*"]
 
 [dependencies]
 
-regex = "0.1"
+regex = "1.0"
 
-serde = "0.9"       # serialization
-serde_derive = "0.9"
+serde = "1.0"       # serialization
+serde_derive = "1.0"
 
 clang = "0.16"    # C++ parsing
 
@@ -26,4 +26,4 @@ clippy = {version = "0.0", optional = true} # linter
 
 cpp_to_rust_common = { version = "0.2.3", path = "../../cpp_to_rust/cpp_to_rust_common" }
 
-lazy_static = "1.0" # regex caching
+lazy_static = "1.1" # regex caching

--- a/cpp_to_rust/cpp_to_rust_generator/Cargo.toml
+++ b/cpp_to_rust/cpp_to_rust_generator/Cargo.toml
@@ -16,7 +16,7 @@ serde_derive = "1.0"
 
 clang = "0.16"    # C++ parsing
 
-select = "0.3.0"    # html parsing
+select = "0.4.2"    # html parsing
 
 tempdir = "0.3.5"   # temporary directory creation
 

--- a/cpp_to_rust/cpp_to_rust_generator/src/config.rs
+++ b/cpp_to_rust/cpp_to_rust_generator/src/config.rs
@@ -64,7 +64,7 @@ pub struct CrateProperties {
   /// Version of the crate (must be in compliance with cargo requirements)
   version: String,
   /// Extra properties to be merged with auto generated content of `Cargo.toml`
-  custom_fields: common::toml::Table,
+  custom_fields: common::toml::value::Table,
   /// Extra dependencies for output `Cargo.toml`
   dependencies: Vec<CrateDependency>,
   /// Extra build dependencies for output `Cargo.toml`
@@ -131,7 +131,7 @@ impl CrateProperties {
 
   /// Sets custom fields for output `Cargo.toml`. These fields will
   /// be added to auto-generated fields (or replace them in case of a name conflict).
-  pub fn set_custom_fields(&mut self, value: common::toml::Table) {
+  pub fn set_custom_fields(&mut self, value: common::toml::value::Table) {
     self.custom_fields = value;
   }
 
@@ -161,7 +161,7 @@ impl CrateProperties {
     self.remove_default_build_dependencies
   }
 
-  pub fn custom_fields(&self) -> &common::toml::Table {
+  pub fn custom_fields(&self) -> &common::toml::value::Table {
     &self.custom_fields
   }
 }

--- a/cpp_to_rust/cpp_to_rust_generator/src/cpp_code_generator.rs
+++ b/cpp_to_rust/cpp_to_rust_generator/src/cpp_code_generator.rs
@@ -2,7 +2,7 @@ use cpp_ffi_data::{QtSlotWrapper, CppIndirectionChange, CppAndFfiMethod, CppFfiA
                    CppFfiHeaderData, CppFfiType, CppFieldAccessorType, CppFfiMethodKind};
 use cpp_method::ReturnValueAllocationPlace;
 use cpp_type::{CppTypeIndirection, CppTypeBase, CppType};
-use common::errors::{Result, ChainErr, unexpected};
+use common::errors::{Result, ResultExt, unexpected};
 use common::file_utils::{PathBufWithAdded, create_dir_all, create_file, path_to_str};
 use common::string_utils::JoinWithSeparator;
 use common::utils::MapIfOk;

--- a/cpp_to_rust/cpp_to_rust_generator/src/cpp_data.rs
+++ b/cpp_to_rust/cpp_to_rust_generator/src/cpp_data.rs
@@ -4,7 +4,7 @@
 use cpp_method::{CppMethod, CppMethodKind};
 pub use cpp_operator::CppOperator;
 use cpp_type::{CppType, CppTypeBase, CppTypeIndirection, CppTypeClassBase};
-use common::errors::{Result, ChainErr};
+use common::errors::{Result, ResultExt};
 use common::file_utils::open_file;
 use common::log;
 

--- a/cpp_to_rust/cpp_to_rust_generator/src/cpp_ffi_generator.rs
+++ b/cpp_to_rust/cpp_to_rust_generator/src/cpp_ffi_generator.rs
@@ -7,7 +7,7 @@ use cpp_ffi_data::{CppAndFfiMethod, c_base_name, CppFfiHeaderData, QtSlotWrapper
                    CppFfiMethodKind, CppFieldAccessorType, CppMethodWithFfiSignature, CppCast};
 use cpp_method::{CppMethod, CppMethodKind, CppMethodArgument, CppMethodClassMembership,
                  ReturnValueAllocationPlace};
-use common::errors::{Result, ChainErr, unexpected};
+use common::errors::{Result, ResultExt, unexpected};
 use common::log;
 use common::utils::{MapIfOk, add_to_multihash};
 use config::CppFfiGeneratorFilterFn;

--- a/cpp_to_rust/cpp_to_rust_generator/src/cpp_parser.rs
+++ b/cpp_to_rust/cpp_to_rust_generator/src/cpp_parser.rs
@@ -6,7 +6,7 @@ use cpp_operator::CppOperator;
 use cpp_type::{CppType, CppTypeBase, CppBuiltInNumericType, CppTypeIndirection,
                CppSpecificNumericTypeKind, CppTypeClassBase, CppSpecificNumericType,
                CppFunctionPointerType};
-use common::errors::{Result, ChainErr, unexpected};
+use common::errors::{Result, ResultExt, unexpected};
 use common::file_utils::{remove_file, open_file, create_file, path_to_str, os_str_to_str};
 use common::string_utils::JoinWithSeparator;
 use common::log;

--- a/cpp_to_rust/cpp_to_rust_generator/src/cpp_parser.rs
+++ b/cpp_to_rust/cpp_to_rust_generator/src/cpp_parser.rs
@@ -340,8 +340,8 @@ impl<'a> CppParser<'a> {
           }
           if let Some(matches) = TEMPLATE_CLASS_REGEX.captures(name.as_ref()) {
             let mut arg_types = Vec::new();
-            if let Some(items) = matches.at(2) {
-              for arg in items.split(',') {
+            if let Some(items) = matches.get(2) {
+              for arg in items.as_str().split(',') {
                 match self.parse_unexposed_type(None,
                                                 Some(arg.trim().to_string()),
                                                 context_class,
@@ -1027,8 +1027,9 @@ impl<'a> CppParser<'a> {
         log::llog(log::DebugParser,
                   || format!("Fixing malformed method name: {}", name));
         name = matches
-          .at(1)
+          .get(1)
           .chain_err(|| "invalid matches count")?
+          .as_str()
           .to_string();
       }
     }

--- a/cpp_to_rust/cpp_to_rust_generator/src/cpp_type.rs
+++ b/cpp_to_rust/cpp_to_rust_generator/src/cpp_type.rs
@@ -2,7 +2,7 @@
 
 use caption_strategy::TypeCaptionStrategy;
 use cpp_ffi_data::{CppFfiType, CppIndirectionChange};
-use common::errors::{Result, ChainErr, Error, unexpected};
+use common::errors::{Result, ResultExt, Error, unexpected};
 use common::string_utils::JoinWithSeparator;
 use common::utils::MapIfOk;
 

--- a/cpp_to_rust/cpp_to_rust_generator/src/launcher.rs
+++ b/cpp_to_rust/cpp_to_rust_generator/src/launcher.rs
@@ -7,7 +7,7 @@ use cpp_data::{CppData, CppDataWithDeps, ParserCppData};
 use cpp_ffi_generator;
 use cpp_parser;
 use cpp_post_processor::cpp_post_process;
-use common::errors::{Result, ChainErr};
+use common::errors::{Result, ResultExt};
 use common::string_utils::CaseOperations;
 use common::file_utils::{PathBufWithAdded, move_files, create_dir_all, save_json, load_bincode,
                          save_bincode, canonicalize, remove_dir_all, remove_dir, read_dir,

--- a/cpp_to_rust/cpp_to_rust_generator/src/rust_code_generator.rs
+++ b/cpp_to_rust/cpp_to_rust_generator/src/rust_code_generator.rs
@@ -267,7 +267,7 @@ impl<'a> RustCodeGenerator<'a> {
     }
     let cargo_toml_data = {
       let package = toml::Value::Table({
-                                         let mut table = toml::Table::new();
+                                         let mut table = toml::value::Table::new();
                                          table.insert("name".to_string(),
                                                       toml::Value::String(self
                                                                             .config
@@ -289,7 +289,7 @@ impl<'a> RustCodeGenerator<'a> {
              toml::Value::String(version.to_string())
            } else {
              toml::Value::Table({
-                                  let mut value = toml::Table::new();
+                                  let mut value = toml::value::Table::new();
                                   value.insert("version".to_string(),
                                                toml::Value::String(version.to_string()));
                                   value.insert("path".to_string(),
@@ -302,7 +302,7 @@ impl<'a> RustCodeGenerator<'a> {
       };
       let dependencies =
         toml::Value::Table({
-                             let mut table = toml::Table::new();
+                             let mut table = toml::value::Table::new();
                              if !self
                                    .config
                                    .crate_properties
@@ -331,7 +331,7 @@ impl<'a> RustCodeGenerator<'a> {
                            });
       let build_dependencies =
         toml::Value::Table({
-                             let mut table = toml::Table::new();
+                             let mut table = toml::value::Table::new();
                              if !self
                                    .config
                                    .crate_properties
@@ -350,7 +350,7 @@ impl<'a> RustCodeGenerator<'a> {
                              }
                              table
                            });
-      let mut table = toml::Table::new();
+      let mut table = toml::value::Table::new();
       table.insert("package".to_string(), package);
       table.insert("dependencies".to_string(), dependencies);
       table.insert("build-dependencies".to_string(), build_dependencies);

--- a/cpp_to_rust/cpp_to_rust_generator/src/rust_code_generator.rs
+++ b/cpp_to_rust/cpp_to_rust_generator/src/rust_code_generator.rs
@@ -1,6 +1,6 @@
 //! Types and functions used for Rust code generation.
 
-use common::errors::{Result, ChainErr, unexpected};
+use common::errors::{Result, ResultExt, unexpected};
 use common::file_utils::{PathBufWithAdded, copy_recursively, file_to_string, copy_file,
                          create_file, create_dir_all, read_dir, os_str_to_str, save_toml,
                          path_to_str, repo_crate_local_path};

--- a/cpp_to_rust/cpp_to_rust_generator/src/rust_code_generator.rs
+++ b/cpp_to_rust/cpp_to_rust_generator/src/rust_code_generator.rs
@@ -160,7 +160,7 @@ pub fn run(config: RustCodeGeneratorConfig, data: &RustGeneratorOutput) -> Resul
   } else {
     include_str!("../templates/crate/rustfmt.toml").to_string()
   };
-  let rustfmt_config = rustfmt::config::Config::from_toml(&rustfmt_config_data);
+  let rustfmt_config = rustfmt::config::Config::from_toml(&rustfmt_config_data)?;
   let generator = RustCodeGenerator {
     config: config,
     rustfmt_config: rustfmt_config,
@@ -1250,11 +1250,13 @@ impl<'a> {connections_mod}::Receiver for {type_name}<'a> {{
 
   /// Runs `rustfmt` on a Rust file `path`.
   fn call_rustfmt(&self, path: &PathBuf) {
-    let result = ::std::panic::catch_unwind(|| {
-                                              rustfmt::format_input(rustfmt::Input::File(path.clone()),
-                            &self.rustfmt_config,
-                            Some(&mut ::std::io::stdout()))
-                                            });
+    let result = ::std::panic::catch_unwind(::std::panic::AssertUnwindSafe(|| {
+      rustfmt::format_input(
+        rustfmt::Input::File(path.clone()),
+        &self.rustfmt_config,
+        Some(&mut ::std::io::stdout()),
+      )
+    }));
     match result {
       Ok(rustfmt_result) => {
         if rustfmt_result.is_err() {

--- a/cpp_to_rust/cpp_to_rust_generator/src/rust_generator.rs
+++ b/cpp_to_rust/cpp_to_rust_generator/src/rust_generator.rs
@@ -9,7 +9,7 @@ use cpp_operator::CppOperator;
 use cpp_type::{CppType, CppTypeBase, CppBuiltInNumericType, CppTypeIndirection,
                CppSpecificNumericTypeKind, CppSpecificNumericType, CppTypeClassBase, CppTypeRole,
                CppFunctionPointerType};
-use common::errors::{Result, ChainErr, unexpected};
+use common::errors::{Result, ResultExt, unexpected};
 use common::log;
 use rust_info::{RustTypeDeclaration, RustTypeDeclarationKind, RustTypeWrapperKind, RustModule,
                 RustMethod, RustMethodScope, RustMethodArgument, RustMethodArgumentsVariant,

--- a/cpp_to_rust/cpp_to_rust_generator/src/rust_type.rs
+++ b/cpp_to_rust/cpp_to_rust_generator/src/rust_type.rs
@@ -1,4 +1,4 @@
-use common::errors::{Result, unexpected, ChainErr};
+use common::errors::{Result, unexpected, ResultExt};
 use common::string_utils::CaseOperations;
 use common::utils::MapIfOk;
 use cpp_type::CppType;

--- a/cpp_to_rust/cpp_utils/src/lib.rs
+++ b/cpp_to_rust/cpp_utils/src/lib.rs
@@ -4,7 +4,7 @@
 mod tests {
   use std::rc::Rc;
   use std::cell::RefCell;
-  use {CppDeletable, Deleter, CppBox};
+  use super::{CppDeletable, Deleter, CppBox};
 
   struct Struct1 {
     value: Rc<RefCell<i32>>,

--- a/cpp_to_rust/cpp_utils/src/lib.rs
+++ b/cpp_to_rust/cpp_utils/src/lib.rs
@@ -42,7 +42,7 @@ pub type Deleter<T> = unsafe extern "C" fn(this_ptr: *mut T);
 /// Indicates that the type can be put into a CppBox.
 ///
 /// Example of implementation:
-/// ```
+/// ```ignore
 /// impl CppDeletable for Struct1 {
 ///   fn deleter() -> Deleter<Self> {
 ///     struct1_delete

--- a/qt_generator/qt_build_tools/src/lib.rs
+++ b/qt_generator/qt_build_tools/src/lib.rs
@@ -7,7 +7,7 @@ extern crate cpp_to_rust_build_tools;
 extern crate qt_generator_common;
 
 use cpp_to_rust_build_tools::Config;
-use cpp_to_rust_build_tools::common::errors::{fancy_unwrap, Result, ChainErr};
+use cpp_to_rust_build_tools::common::errors::{fancy_unwrap, Result, ResultExt};
 use cpp_to_rust_build_tools::common::target;
 use cpp_to_rust_build_tools::common::cpp_build_config::CppBuildConfigData;
 use qt_generator_common::{InstallationData, get_installation_data, real_lib_name, framework_name,

--- a/qt_generator/qt_generator/Cargo.toml
+++ b/qt_generator/qt_generator/Cargo.toml
@@ -13,5 +13,5 @@ qt_generator_common = { version = "0.2.3", path = "../qt_generator_common" }
 clap = "2.23.1"    # command line args parsing
 regex = "1.0"
 rusqlite = "0.14"
-compress = "0.1.2"
+libflate = "0.1"
 select = "0.4.2"    # html parsing

--- a/qt_generator/qt_generator/Cargo.toml
+++ b/qt_generator/qt_generator/Cargo.toml
@@ -11,7 +11,7 @@ cpp_to_rust_generator = { version = "0.2.0", path = "../../cpp_to_rust/cpp_to_ru
 qt_generator_common = { version = "0.2.3", path = "../qt_generator_common" }
 
 clap = "2.23.1"    # command line args parsing
-regex = "0.1"
+regex = "1.0"
 rusqlite = "0.7"
 compress = "0.1.2"
 select = "0.3.0"    # html parsing

--- a/qt_generator/qt_generator/Cargo.toml
+++ b/qt_generator/qt_generator/Cargo.toml
@@ -12,6 +12,6 @@ qt_generator_common = { version = "0.2.3", path = "../qt_generator_common" }
 
 clap = "2.23.1"    # command line args parsing
 regex = "1.0"
-rusqlite = "0.7"
+rusqlite = "0.14"
 compress = "0.1.2"
 select = "0.4.2"    # html parsing

--- a/qt_generator/qt_generator/Cargo.toml
+++ b/qt_generator/qt_generator/Cargo.toml
@@ -14,4 +14,4 @@ clap = "2.23.1"    # command line args parsing
 regex = "1.0"
 rusqlite = "0.7"
 compress = "0.1.2"
-select = "0.3.0"    # html parsing
+select = "0.4.2"    # html parsing

--- a/qt_generator/qt_generator/src/doc_decoder.rs
+++ b/qt_generator/qt_generator/src/doc_decoder.rs
@@ -1,6 +1,6 @@
 //! Converts Qt docs from the internal format.
 
-use cpp_to_rust_generator::common::errors::{Result, ChainErr};
+use cpp_to_rust_generator::common::errors::{Result, ResultExt};
 use cpp_to_rust_generator::common::file_utils::PathBufWithAdded;
 use cpp_to_rust_generator::common::log;
 use html_parser::document::Document;

--- a/qt_generator/qt_generator/src/doc_decoder.rs
+++ b/qt_generator/qt_generator/src/doc_decoder.rs
@@ -111,7 +111,7 @@ impl DocData {
     }
     log::status(format!("Adding Qt documentation from {}", doc_file_path.display()));
     let connection = rusqlite::Connection::open_with_flags(&doc_file_path,
-                                                           rusqlite::SQLITE_OPEN_READ_ONLY)
+                                                           rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY)
         .convert_err()?;
 
     let mut index_data = Vec::new();

--- a/qt_generator/qt_generator/src/doc_decoder.rs
+++ b/qt_generator/qt_generator/src/doc_decoder.rs
@@ -84,7 +84,7 @@ impl DocData {
       .index
       .iter_mut()
       .find(|item| f(item))
-      .and_then(|mut item| {
+      .and_then(|item| {
                   item.accessed = true;
                   Some(item.clone())
                 })

--- a/qt_generator/qt_generator/src/doc_decoder.rs
+++ b/qt_generator/qt_generator/src/doc_decoder.rs
@@ -44,7 +44,7 @@ pub struct DocIndexItem {
 
 use std::io::Read;
 
-use compress;
+use libflate;
 
 impl DocData {
   /// Returns all index items.
@@ -61,8 +61,8 @@ impl DocData {
     let file_data = file_data.convert_err()?;
     let file_data: Vec<u8> = file_data.get_checked(0).convert_err()?;
     let mut file_html = Vec::new();
-    compress::zlib::Decoder::new(&file_data[4..])
-      .read_to_end(&mut file_html)
+    libflate::zlib::Decoder::new(&file_data[4..])
+      .and_then(|mut decoder| decoder.read_to_end(&mut file_html))
       .map_err(|err| format!("zlib decoder failed: {}", err))?;
     let file_html = String::from_utf8_lossy(&file_html);
     Ok(Document::from(file_html.as_ref()))

--- a/qt_generator/qt_generator/src/doc_parser.rs
+++ b/qt_generator/qt_generator/src/doc_parser.rs
@@ -430,12 +430,12 @@ fn process_html(html: &str, base_url: &str) -> Result<(String, HashSet<String>)>
   let html = link_regex.replace_all(html.trim(), |captures: &::regex::Captures| {
     let mut link = bad_subfolder_regex.replace(&captures[2], "");
     if !link.contains(":") {
-      link = format!("{}{}", base_url, link);
-      cross_references.insert(link.clone());
+      link = format!("{}{}", base_url, link).into();
+      cross_references.insert(link.clone().into_owned());
     }
     format!("{}=\"{}\"", &captures[1], link)
   });
-  Ok((html, cross_references))
+  Ok((html.into(), cross_references))
 }
 
 /// Parses document to a list of `ItemDoc`s.

--- a/qt_generator/qt_generator/src/doc_parser.rs
+++ b/qt_generator/qt_generator/src/doc_parser.rs
@@ -4,7 +4,7 @@
 use doc_decoder::DocData;
 use std::collections::{hash_map, HashMap, HashSet};
 use cpp_to_rust_generator::common::log;
-use cpp_to_rust_generator::common::errors::{Result, ChainErr, unexpected};
+use cpp_to_rust_generator::common::errors::{Result, ResultExt, unexpected};
 use cpp_to_rust_generator::cpp_method::CppMethodDoc;
 use cpp_to_rust_generator::cpp_data::CppTypeDoc;
 use html_parser::node::Node;

--- a/qt_generator/qt_generator/src/executor.rs
+++ b/qt_generator/qt_generator/src/executor.rs
@@ -107,8 +107,8 @@ fn make_config(sublib_name: &str,
   let crate_name = format!("qt_{}", sublib_name);
   let mut crate_properties = CrateProperties::new(crate_name.clone(),
                                                   versions::QT_OUTPUT_CRATES_VERSION);
-  let mut custom_fields = toml::Table::new();
-  let mut package_data = toml::Table::new();
+  let mut custom_fields = toml::value::Table::new();
+  let mut package_data = toml::value::Table::new();
   package_data.insert("authors".to_string(),
                       toml::Value::Array(vec![toml::Value::String("Pavel Strakhov <ri@idzaaus.org>"
                                                                     .to_string())]));

--- a/qt_generator/qt_generator/src/fix_header_names.rs
+++ b/qt_generator/qt_generator/src/fix_header_names.rs
@@ -2,7 +2,7 @@
 //! Qt's shortcut header names.
 
 use cpp_to_rust_generator::cpp_data::ParserCppData;
-use cpp_to_rust_generator::common::errors::{Result, ChainErr};
+use cpp_to_rust_generator::common::errors::{Result, ResultExt};
 use cpp_to_rust_generator::common::file_utils::{read_dir, file_to_string, os_str_to_str};
 use cpp_to_rust_generator::common::log;
 use cpp_to_rust_generator::common::utils::add_to_multihash;

--- a/qt_generator/qt_generator/src/fix_header_names.rs
+++ b/qt_generator/qt_generator/src/fix_header_names.rs
@@ -50,8 +50,9 @@ impl HeaderNameMap {
         let file_content = file_to_string(&header_path)?;
         if let Some(matches) = re.captures(file_content.trim()) {
           let real_header = matches
-            .at(1)
+            .get(1)
             .chain_err(|| "invalid regexp matches")?
+            .as_str()
             .to_string();
           let fancy_header = os_str_to_str(&header.file_name())?.to_string();
           add_to_multihash(&mut map_real_to_all_fancy, real_header, fancy_header);

--- a/qt_generator/qt_generator/src/lib_configs.rs
+++ b/qt_generator/qt_generator/src/lib_configs.rs
@@ -1,6 +1,6 @@
 //! Generator configurations specific for each Qt module.
 
-use cpp_to_rust_generator::common::errors::{Result, ChainErr};
+use cpp_to_rust_generator::common::errors::{Result, ResultExt};
 use cpp_to_rust_generator::config::{Config, CppTypeAllocationPlace};
 use cpp_to_rust_generator::cpp_type::{CppType, CppTypeBase, CppBuiltInNumericType,
                                       CppTypeIndirection};

--- a/qt_generator/qt_generator/src/main.rs
+++ b/qt_generator/qt_generator/src/main.rs
@@ -7,7 +7,7 @@
 extern crate clap;
 extern crate cpp_to_rust_generator;
 extern crate rusqlite;
-extern crate compress;
+extern crate libflate;
 extern crate select as html_parser;
 extern crate regex;
 extern crate qt_generator_common;

--- a/qt_generator/qt_generator/src/main.rs
+++ b/qt_generator/qt_generator/src/main.rs
@@ -12,7 +12,7 @@ extern crate select as html_parser;
 extern crate regex;
 extern crate qt_generator_common;
 
-use cpp_to_rust_generator::common::errors::{Result, ChainErr};
+use cpp_to_rust_generator::common::errors::{Result, ResultExt};
 use cpp_to_rust_generator::common::file_utils::{create_dir_all, canonicalize};
 use cpp_to_rust_generator::config::{CacheUsage, DebugLoggingConfig};
 use std::path::PathBuf;


### PR DESCRIPTION
It may involve to increase the minimum required version.

Also, the [workspace manifest file][1] was added so all crates in this repo can be built at once using `cargo build --all`.

[1]: https://github.com/rust-qt/cpp_to_rust/pull/74/files#diff-80398c5faae3c069e4e6aa2ed11b28c0