### PR TITLE
Fix Qt crate documentation URLs

### DIFF
--- a/qt_ritual/src/lib_configs.rs
+++ b/qt_ritual/src/lib_configs.rs
@@ -58,7 +58,7 @@ pub fn create_config(
     );
     let description = format!("Bindings for {} C++ library", lib_folder_name(&crate_name));
     package_data.insert("description".to_string(), toml::Value::String(description));
-    let doc_url = format!("https://rust-qt.github.io/rustdoc/qt/{}", &crate_name);
+    let doc_url = format!("https://docs.rs/{}", &crate_name);
     package_data.insert("documentation".to_string(), toml::Value::String(doc_url));
     package_data.insert(
         "repository".to_string(),


### PR DESCRIPTION
Thank you for creating and maintaining these bindings! This is a one-liner to fix the generated documentation URLs for the Qt crates which are currently pointing to pages which don’t exist.