### PR TITLE
Fix #107 by switching to proc_macro2::Span

### DIFF
--- a/qt_macros/src/q_init_resource.rs
+++ b/qt_macros/src/q_init_resource.rs
@@ -1,6 +1,7 @@
 use proc_macro::TokenStream;
+use proc_macro2::Span;
 use quote::quote;
-use syn::{export::Span, parse_macro_input, Ident, LitStr};
+use syn::{parse_macro_input, Ident, LitStr};
 
 pub fn q_init_resource(input: TokenStream) -> TokenStream {
     let resource_name = parse_macro_input!(input as LitStr).value();

--- a/qt_macros/src/slot.rs
+++ b/qt_macros/src/slot.rs
@@ -1,6 +1,7 @@
 use proc_macro::TokenStream;
+use proc_macro2::Span;
 use quote::quote;
-use syn::{export::Span, parse_macro_input, Ident, ItemFn};
+use syn::{parse_macro_input, Ident, ItemFn};
 
 pub fn slot(attrs: TokenStream, input: TokenStream) -> TokenStream {
     let slot_type = parse_macro_input!(attrs as Ident);


### PR DESCRIPTION
Issue caused by incorrect use of a private method of upstream
`syn::export::Span`.

With the commit
https://github.com/dtolnay/syn/commit/957840eba2c7f11c95e0227760d78dc481a91de7
`syn` has further removed from the public API the `export` private
interface, and thus the `Span`.

However, `Span` in `sys` was re-exported from crate `proc_macro2`.

The fix imports `Span` straight from `proc_macro2` without `sys`
intermediation.