### PR TITLE
update clang dependency to 1.0

### DIFF
--- a/ritual/Cargo.toml
+++ b/ritual/Cargo.toml
@@ -15,7 +15,7 @@ ritual_common = { version = "0.4.0", path = "../ritual_common" }
 regex = "1.1.0"
 serde = { version = "1.0.84", features = ["rc"] }
 serde_derive = "1.0.84"
-clang = "0.20.0"    # C++ parsing
+clang = "1.0"       # C++ parsing
 select = "0.4.2"    # html parsing
 tempdir = "0.3.7"   # temporary directory creation
 derive_more = "0.13.0"


### PR DESCRIPTION
This updates the `clang` dependency for the `ritual` crate from 0.20.0 to 1.0(.3). This fixes an issue for me on Gentoo where the older version of `clang-sys` that `clang` depends on, where it tries to use `/usr/lib/llvm/12/lib/libclang.so` (the 32-bit version) rather than `/usr/lib/llvm/12/lib64/libclang.so` (the 64-bit version). On distributions other than Ubuntu and Debian, the 64-bit versions of libraries may be located in `/usr/lib64` or a similarly named `lib64` directory.