### PR TITLE
Fix urlopen SSL certificate error when using the docker containers

### DIFF
--- a/scripts/docker/qt.dockerfile
+++ b/scripts/docker/qt.dockerfile
@@ -1,6 +1,6 @@
 FROM debian:buster as qt_downloader
 RUN apt-get update
-RUN apt-get install -y python3-bs4 p7zip-full
+RUN apt-get install -y python3-bs4 p7zip-full ca-certificates
 RUN mkdir -p /opt/qt
 WORKDIR /opt/qt
 COPY scripts/install_qt.py /


### PR DESCRIPTION

building the qt_downloader container fails with a urlopen ssl certificate error.

This can be fixed,  by installing the ca-certificates package before running the install_qt.py script, which is all this PR does.

<details>
  <summary>failing docker build log</summary>

```
[1/2] STEP 1/7: FROM debian:buster AS qt_downloader
[1/2] STEP 2/7: RUN apt-get update
--> Using cache a7e9e2816fb757acdc1024538103e345abfc85ec9521a26a06799a39693af85c
--> a7e9e2816fb7
[1/2] STEP 3/7: RUN apt-get install -y python3-bs4 p7zip-full
--> Using cache 71040fc6a8c1b649b17a2e4b076fdc0328ec26f2297fb1cd6a493e439f2c23e0
--> 71040fc6a8c1
[1/2] STEP 4/7: RUN mkdir -p /opt/qt
--> Using cache 0e4973c54a58c846c06d98adc5864646c8443ca5f844da1fdc70e45012dd68cf
--> 0e4973c54a58
[1/2] STEP 5/7: WORKDIR /opt/qt
--> Using cache 2451c4355b2e4a00df4763194772f8d48e11b9981f67c54d8dbedf5513858633
--> 2451c4355b2e
[1/2] STEP 6/7: COPY scripts/install_qt.py /
--> Using cache 6da8784df45b5cef1ba889b08da0c57a87ca538daac2650195e16e7a33ded0c6
--> 6da8784df45b
[1/2] STEP 7/7: RUN /install_qt.py 5.9.7 linux_x64 gcc_64 &&     /install_qt.py 5.9.7 --docs &&     /install_qt.py 5.11.3 linux_x64 gcc_64 &&     /install_qt.py 5.11.3 --docs &&     /install_qt.py 5.12.2 linux_x64 gcc_64 &&     /install_qt.py 5.12.2 --docs &&     /install_qt.py 5.13.0 linux_x64 gcc_64 &&     /install_qt.py 5.13.0 --docs &&     /install_qt.py 5.14.0 linux_x64 gcc_64 &&     /install_qt.py 5.14.0 --docs
Installing Qt 5.9.7
Downloading file list from http://download.qt.io/online/qtsdkrepository/linux_x64/desktop/qt5_597/qt.qt5.597.gcc_64/
Traceback (most recent call last):
  File "/usr/lib/python3.7/urllib/request.py", line 1324, in do_open
    encode_chunked=req.has_header('Transfer-encoding'))
  File "/usr/lib/python3.7/http/client.py", line 1264, in request
    self._send_request(method, url, body, headers, encode_chunked)
  File "/usr/lib/python3.7/http/client.py", line 1310, in _send_request
    self.endheaders(body, encode_chunked=encode_chunked)
  File "/usr/lib/python3.7/http/client.py", line 1259, in endheaders
    self._send_output(message_body, encode_chunked=encode_chunked)
  File "/usr/lib/python3.7/http/client.py", line 1034, in _send_output
    self.send(msg)
  File "/usr/lib/python3.7/http/client.py", line 974, in send
    self.connect()
  File "/usr/lib/python3.7/http/client.py", line 1427, in connect
    server_hostname=server_hostname)
  File "/usr/lib/python3.7/ssl.py", line 412, in wrap_socket
    session=session
  File "/usr/lib/python3.7/ssl.py", line 886, in _create
    self.do_handshake()
  File "/usr/lib/python3.7/ssl.py", line 1150, in do_handshake
    self._sslobj.do_handshake()
ssl.SSLCertVerificationError: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:1056)

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/install_qt.py", line 112, in <module>
    modules
  File "/install_qt.py", line 43, in install_dir
    links = get_links(remote_dir)
  File "/install_qt.py", line 13, in get_links
    html_page = urlopen(url).read().decode('utf-8')
  File "/usr/lib/python3.7/urllib/request.py", line 222, in urlopen
    return opener.open(url, data, timeout)
  File "/usr/lib/python3.7/urllib/request.py", line 531, in open
    response = meth(req, response)
  File "/usr/lib/python3.7/urllib/request.py", line 641, in http_response
    'http', request, response, code, msg, hdrs)
  File "/usr/lib/python3.7/urllib/request.py", line 563, in error
    result = self._call_chain(*args)
  File "/usr/lib/python3.7/urllib/request.py", line 503, in _call_chain
    result = func(*args)
  File "/usr/lib/python3.7/urllib/request.py", line 755, in http_error_302
    return self.parent.open(new, timeout=req.timeout)
  File "/usr/lib/python3.7/urllib/request.py", line 525, in open
    response = self._open(req, data)
  File "/usr/lib/python3.7/urllib/request.py", line 543, in _open
    '_open', req)
  File "/usr/lib/python3.7/urllib/request.py", line 503, in _call_chain
    result = func(*args)
  File "/usr/lib/python3.7/urllib/request.py", line 1367, in https_open
    context=self._context, check_hostname=self._check_hostname)
  File "/usr/lib/python3.7/urllib/request.py", line 1326, in do_open
    raise URLError(err)
urllib.error.URLError: <urlopen error [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:1056)>
Error: building at STEP "RUN /install_qt.py 5.9.7 linux_x64 gcc_64 &&     /install_qt.py 5.9.7 --docs &&     /install_qt.py 5.11.3 linux_x64 gcc_64 &&     /install_qt.py 5.11.3 --docs &&     /install_qt.py 5.12.2 linux_x64 gcc_64 &&     /install_qt.py 5.12.2 --docs &&     /install_qt.py 5.13.0 linux_x64 gcc_64 &&     /install_qt.py 5.13.0 --docs &&     /install_qt.py 5.14.0 linux_x64 gcc_64 &&     /install_qt.py 5.14.0 --docs": while running runtime: exit status 1
```

</details>